### PR TITLE
Removed link to http://emoji.codes/ in the navigation since the site is gone.

### DIFF
--- a/client/template.html
+++ b/client/template.html
@@ -62,7 +62,6 @@
 									<ul class="dropdown-menu">
 										<li><a onclick="toggleJsonDisplayMode ();" id="idJsonMenuItem"></a></li>
 										<li><a href="http://guidelines.scripting.com/" target="_blank">Comment guidelines..</a></li>
-										<li><a href="http://emoji.codes/" target="_blank">Emoji codes..</a></li>
 										</ul>
 									</li>
 								<li class="dropdown" id="idSysopMenu" style="display: none;"> 


### PR DESCRIPTION
Looking at web.archive.org it looks like the emoji.codes site may have vanished near the end of 2017:

http://web.archive.org/web/20190501000000*/http://emoji.codes/